### PR TITLE
Fixed bug causing setState() called after dispose error

### DIFF
--- a/lib/subtitle_text_view.dart
+++ b/lib/subtitle_text_view.dart
@@ -10,11 +10,10 @@ class SubtitleTextView extends StatefulWidget {
   final VideoPlayerController videoPlayerController;
   final SubtitleStyle subtitleStyle;
 
-  const SubtitleTextView(
-      {Key key,
-      @required this.subtitleController,
-      this.videoPlayerController,
-      this.subtitleStyle})
+  const SubtitleTextView({Key key,
+    @required this.subtitleController,
+    this.videoPlayerController,
+    this.subtitleStyle})
       : super(key: key);
 
   @override
@@ -25,13 +24,14 @@ class SubtitleTextView extends StatefulWidget {
 class _SubtitleTextViewState extends State<SubtitleTextView> {
   final VideoPlayerController videoPlayerController;
   Subtitle subtitle;
+  Function listener;
 
   _SubtitleTextViewState(this.videoPlayerController);
 
   @override
   void initState() {
-    videoPlayerController
-        .addListener(() => _subtitleWatcher(videoPlayerController));
+    listener = () => _subtitleWatcher(videoPlayerController);
+    videoPlayerController.addListener(listener);
 
     _subtitleWatcher(videoPlayerController);
     super.initState();
@@ -45,56 +45,64 @@ class _SubtitleTextViewState extends State<SubtitleTextView> {
     if (videoPlayerPosition != null) {
       subtitles.subtitles.forEach((Subtitle subtitleItem) {
         if (videoPlayerPosition.inMilliseconds >
-                subtitleItem.startTime.inMilliseconds &&
+            subtitleItem.startTime.inMilliseconds &&
             videoPlayerPosition.inMilliseconds <
                 subtitleItem.endTime.inMilliseconds) {
-          setState(() {
-            subtitle = subtitleItem;
-          });
+          if (this.mounted) {
+            setState(() {
+              subtitle = subtitleItem;
+            });
+          }
         }
       });
     }
   }
 
   @override
+  void dispose() {
+    videoPlayerController.removeListener(listener);
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return subtitle != null
         ? Container(
-            child: Stack(
-              children: <Widget>[
-                widget.subtitleStyle.hasBorder
-                    ? Center(
-                        child: Text(
-                          subtitle.text,
-                          textAlign: TextAlign.center,
-                          style: TextStyle(
-                            fontSize: widget.subtitleStyle.fontSize,
-                            foreground: Paint()
-                              ..style = widget.subtitleStyle.borderStyle.style
-                              ..strokeWidth =
-                                  widget.subtitleStyle.borderStyle.strokeWidth
-                              ..color = widget.subtitleStyle.borderStyle.color,
-                          ),
-                        ),
-                      )
-                    : Container(
-                        child: null,
-                      ),
-                Center(
-                  child: Text(
-                    subtitle.text,
-                    textAlign: TextAlign.center,
-                    style: TextStyle(
-                      fontSize: widget.subtitleStyle.fontSize,
-                      color: widget.subtitleStyle.textColor,
-                    ),
-                  ),
-                ),
-              ],
+      child: Stack(
+        children: <Widget>[
+          widget.subtitleStyle.hasBorder
+              ? Center(
+            child: Text(
+              subtitle.text,
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                fontSize: widget.subtitleStyle.fontSize,
+                foreground: Paint()
+                  ..style = widget.subtitleStyle.borderStyle.style
+                  ..strokeWidth =
+                      widget.subtitleStyle.borderStyle.strokeWidth
+                  ..color = widget.subtitleStyle.borderStyle.color,
+              ),
             ),
           )
-        : Container(
+              : Container(
             child: null,
-          );
+          ),
+          Center(
+            child: Text(
+              subtitle.text,
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                fontSize: widget.subtitleStyle.fontSize,
+                color: widget.subtitleStyle.textColor,
+              ),
+            ),
+          ),
+        ],
+      ),
+    )
+        : Container(
+      child: null,
+    );
   }
 }


### PR DESCRIPTION
I now render widget SubtitleTextView directly inside my ChewieCustomControl-widgets. This is working perfectly for our use case and is a perfect workaround for issue #1. Thanks again!
While doing this, I recognized that SubtitleTextView sometimes calls setState while not being mounted, because it's called from a listener. This causes errors.
To fix this, I suggest to remove the listener on dispose of the widget. To ensure the bug doesn't cause any errors, you can also check if the widget is mounted before calling setState().
