### PR TITLE
Fix SRT text not matched for more than two lines of text

### DIFF
--- a/lib/data/repository/subtitle_repository.dart
+++ b/lib/data/repository/subtitle_repository.dart
@@ -147,7 +147,7 @@ class SubtitleDataRepository extends SubtitleRepository {
       );
     } else if (subtitleType == SubtitleType.srt) {
       regExp = RegExp(
-        r'((\d{2}):(\d{2}):(\d{2})\,(\d+)) +--> +((\d{2}):(\d{2}):(\d{2})\,(\d{3})).*[\r\n]+\s*((?:(?!\r?\n\r?).)*(\r\n|\r|\n)(?:.*))',
+        r'((\d{2}):(\d{2}):(\d{2})\,(\d+)) +--> +((\d{2}):(\d{2}):(\d{2})\,(\d{3})).*[\r\n]+\s*(^[\s\S]*?(?=\n{2,}))',
         caseSensitive: false,
         multiLine: true,
       );


### PR DESCRIPTION
This is a brief regular expression fix to #53 which simplifies the regular expression used to match text for SRT until a blank line is found, following the [SRT specification](https://www.matroska.org/technical/subtitles.html#srt-subtitles) I mentioned in the issue:

> It consists of four parts, all in text:
>
>1. A number indicating which subtitle it is in the sequence. 
>2. The time that the subtitle appears on the screen, and then disappears. 
>3. The subtitle itself. 
>4. A blank line indicating the start of a new subtitle.

I've tested it on a variety of subtitles I have, but maybe I didn't cover some ground.

Also, just want to add I use a highly modified fork of this in my [language learning app](https://github.com/lrorpilla/jidoujisho) and this subtitle wrapper is an essential part of my app's core functionality (I modified it for tap and drag text selection), so I really appreciate this package. I really couldn't have done much if this didn't exist to begin with.