### PR TITLE
Subtitle fix for no lines at video player position

### DIFF
--- a/lib/bloc/subtitle/subtitle_bloc.dart
+++ b/lib/bloc/subtitle/subtitle_bloc.dart
@@ -50,19 +50,22 @@ class SubtitleBloc extends Bloc<SubtitleEvent, SubtitleState> {
     videoPlayerController.addListener(
       () {
         final videoPlayerPosition = videoPlayerController.value.position;
-        for (final Subtitle subtitleItem in subtitles.subtitles) {
-          final bool validStartTime = videoPlayerPosition.inMilliseconds >
-              subtitleItem.startTime.inMilliseconds;
-          final bool validEndTime = videoPlayerPosition.inMilliseconds <
-              subtitleItem.endTime.inMilliseconds;
-          if (validStartTime && validEndTime) {
-            add(
-              UpdateLoadedSubtitle(
-                subtitle: subtitleItem,
-              ),
-            );
-          }
-        }
+
+        Subtitle subtitle = subtitles.subtitles.firstWhere(
+          (Subtitle subtitleItem) {
+            final bool validStartTime = videoPlayerPosition.inMilliseconds >
+                subtitleItem.startTime.inMilliseconds;
+            final bool validEndTime = videoPlayerPosition.inMilliseconds <
+                subtitleItem.endTime.inMilliseconds;
+            return (validStartTime && validEndTime);
+          },
+          orElse: () => null,
+        );
+        add(
+          UpdateLoadedSubtitle(
+            subtitle: subtitle,
+          ),
+        );
       },
     );
   }


### PR DESCRIPTION
When no subtitle at the current video player position is available remove the last one showed. Since the end time of the last subtitle is passed.