### PR TITLE
Remove listener when bloc is closed

### DIFF
--- a/lib/bloc/subtitle/subtitle_bloc.dart
+++ b/lib/bloc/subtitle/subtitle_bloc.dart
@@ -44,33 +44,36 @@ class SubtitleBloc extends Bloc<SubtitleEvent, SubtitleState> {
   }) async {
     emit(LoadingSubtitle());
     videoPlayerController.addListener(
-      () {
-        final videoPlayerPosition = videoPlayerController.value.position;
-        if (videoPlayerPosition.inMilliseconds >
-            subtitles.subtitles.last.endTime.inMilliseconds) {
-          add(CompletedShowingSubtitles());
-        }
-        for (final Subtitle subtitleItem in subtitles.subtitles) {
-          final bool validStartTime = videoPlayerPosition.inMilliseconds >
-              subtitleItem.startTime.inMilliseconds;
-          final bool validEndTime = videoPlayerPosition.inMilliseconds <
-              subtitleItem.endTime.inMilliseconds;
-          if (validStartTime && validEndTime) {
-            add(
-              UpdateLoadedSubtitle(
-                subtitle: subtitleItem,
-              ),
-            );
-          }
-        }
-      },
+      _listener,
     );
   }
 
   @override
   Future<void> close() {
     subtitleController.detach();
+    videoPlayerController.removeListener(_listener);
 
     return super.close();
+  }
+
+  void _listener() {
+    final videoPlayerPosition = videoPlayerController.value.position;
+    if (videoPlayerPosition.inMilliseconds >
+        subtitles.subtitles.last.endTime.inMilliseconds) {
+      add(CompletedShowingSubtitles());
+    }
+    for (final Subtitle subtitleItem in subtitles.subtitles) {
+      final bool validStartTime = videoPlayerPosition.inMilliseconds >
+          subtitleItem.startTime.inMilliseconds;
+      final bool validEndTime = videoPlayerPosition.inMilliseconds <
+          subtitleItem.endTime.inMilliseconds;
+      if (validStartTime && validEndTime) {
+        add(
+          UpdateLoadedSubtitle(
+            subtitle: subtitleItem,
+          ),
+        );
+      }
+    }
   }
 }


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

I found out that when the bloc was closed, it was not properly removing the listener that updates the bloc state. This is problematic when the video wrapper widget is used in more than one place. For example in a larger fullscreen view as well on a different screen.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore