### PR TITLE
Add check for empty content

### DIFF
--- a/lib/bloc/subtitle/subtitle_bloc.dart
+++ b/lib/bloc/subtitle/subtitle_bloc.dart
@@ -47,7 +47,7 @@ class SubtitleBloc extends Bloc<SubtitleEvent, SubtitleState> {
     videoPlayerController.addListener(
       () {
         final videoPlayerPosition = videoPlayerController.value.position;
-        if (!subtitles.subtitles.isNotEmpty &&
+        if (subtitles.subtitles.isNotEmpty &&
             videoPlayerPosition.inMilliseconds >
                 subtitles.subtitles.last.endTime.inMilliseconds) {
           add(CompletedShowingSubtitles());

--- a/lib/bloc/subtitle/subtitle_bloc.dart
+++ b/lib/bloc/subtitle/subtitle_bloc.dart
@@ -47,8 +47,9 @@ class SubtitleBloc extends Bloc<SubtitleEvent, SubtitleState> {
     videoPlayerController.addListener(
       () {
         final videoPlayerPosition = videoPlayerController.value.position;
-        if (videoPlayerPosition.inMilliseconds >
-            subtitles.subtitles.last.endTime.inMilliseconds) {
+        if (!subtitles.subtitles.isNotEmpty &&
+            videoPlayerPosition.inMilliseconds >
+                subtitles.subtitles.last.endTime.inMilliseconds) {
           add(CompletedShowingSubtitles());
         }
         for (final subtitleItem in subtitles.subtitles) {

--- a/lib/data/repository/subtitle_repository.dart
+++ b/lib/data/repository/subtitle_repository.dart
@@ -59,48 +59,53 @@ class SubtitleDataRepository extends SubtitleRepository {
     final subtitleDecoder = subtitleController.subtitleDecoder;
     String? subtitlesContent;
     // Try loading the subtitle content with http.get.
-    final response = await http.get(
-      Uri.parse(subtitleUrl),
-    );
-    // Lets check if the request was successful.
-    // If the subtitle decoder type is utf8 lets decode it with utf8.
-    if (response.statusCode == HttpStatus.ok) {
-      if (subtitleDecoder == SubtitleDecoder.utf8) {
-        subtitlesContent = utf8.decode(
-          response.bodyBytes,
-          allowMalformed: true,
-        );
-      }
-      // If the subtitle decoder type is latin1 lets decode it with latin1.
-      else if (subtitleDecoder == SubtitleDecoder.latin1) {
-        subtitlesContent = latin1.decode(
-          response.bodyBytes,
-          allowInvalid: true,
-        );
-      }
-      // The subtitle decoder was not defined so we will extract it from the response headers send from the server.
-      else {
-        final subtitleServerDecoder = requestContentType(
-          response.headers,
-        );
-        // If the subtitle decoder type is utf8 lets decode it with utf8.
-        if (subtitleServerDecoder == SubtitleDecoder.utf8) {
+    try {
+      final response = await http.get(
+        Uri.parse(subtitleUrl),
+      );
+
+      // Lets check if the request was successful.
+      // If the subtitle decoder type is utf8 lets decode it with utf8.
+      if (response.statusCode == HttpStatus.ok) {
+        if (subtitleDecoder == SubtitleDecoder.utf8) {
           subtitlesContent = utf8.decode(
             response.bodyBytes,
             allowMalformed: true,
           );
         }
         // If the subtitle decoder type is latin1 lets decode it with latin1.
-        else if (subtitleServerDecoder == SubtitleDecoder.latin1) {
+        else if (subtitleDecoder == SubtitleDecoder.latin1) {
           subtitlesContent = latin1.decode(
             response.bodyBytes,
             allowInvalid: true,
           );
         }
+        // The subtitle decoder was not defined so we will extract it from the response headers send from the server.
+        else {
+          final subtitleServerDecoder = requestContentType(
+            response.headers,
+          );
+          // If the subtitle decoder type is utf8 lets decode it with utf8.
+          if (subtitleServerDecoder == SubtitleDecoder.utf8) {
+            subtitlesContent = utf8.decode(
+              response.bodyBytes,
+              allowMalformed: true,
+            );
+          }
+          // If the subtitle decoder type is latin1 lets decode it with latin1.
+          else if (subtitleServerDecoder == SubtitleDecoder.latin1) {
+            subtitlesContent = latin1.decode(
+              response.bodyBytes,
+              allowInvalid: true,
+            );
+          }
+        }
       }
+    } catch (e) {
+      subtitlesContent = '';
     }
-    // Return the subtitle content.
 
+    // Return the subtitle content.
     return subtitlesContent;
   }
 


### PR DESCRIPTION
## Description

Currently the player crashes, if the subtitle URL is empty, or there are no subtitles in the subtitlesContent. This adds a check for those instances and simply leaves the subtitles empty. This will also enable subtitles to be turned off, but simply updating the URL or content to empty.


## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore